### PR TITLE
Add wrapper function for get_page_image()

### DIFF
--- a/demo/django_docusign_demo/tests.py
+++ b/demo/django_docusign_demo/tests.py
@@ -419,3 +419,14 @@ class DocuSignBackendTestCase(unittest.TestCase):
             backend = django_docusign.DocuSignBackend(**explicit_options)
         for key, value in explicit_options.items():
             self.assertEqual(getattr(backend.docusign_client, key), value)
+
+    @mock.patch('pydocusign.DocuSignClient.get_page_image')
+    def test_get_page_image(self, mock_get_page_image):
+        backend = django_docusign.DocuSignBackend()
+
+        signature = mock.Mock()
+        signature.signature_backend_id = 999
+
+        backend.get_page_image(signature, 1, 1, 72, 300)
+
+        mock_get_page_image.assert_called_once_with(999, 1, 1, 72, 300, None)

--- a/django_docusign/backend.py
+++ b/django_docusign/backend.py
@@ -242,3 +242,9 @@ class DocuSignBackend(django_anysign.SignatureBackend):
             recipient=docusign_signer,
             returnUrl=signer_return_url
         )
+
+    def get_page_image(self, signature, document_id, page_no, dpi=None,
+                       max_width=None, max_height=None):
+        envelope_id = signature.signature_backend_id
+        return self.docusign_client.get_page_image(
+            envelope_id, document_id, page_no, dpi, max_width, max_height)


### PR DESCRIPTION
ref #85

Note: this relies on https://github.com/peopledoc/pydocusign/pull/114, which has not been released to pypi yet.