### PR TITLE
Add tox targets for Django 2.1 & Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+dist: xenial
 sudo: false
 language: python
 matrix:
+  fast_finish: true
   include:
     # Python version is just for the look on travis.
     - python: 3.6
@@ -54,14 +56,30 @@ matrix:
     - python: 3.5
       env: TOXENV=py35-django20
 
+    - python: 3.5
+      env: TOXENV=py35-django21
+
     - python: 3.6
       env: TOXENV=py36-django111
 
     - python: 3.6
       env: TOXENV=py36-django20
 
+    - python: 3.6
+      env: TOXENV=py36-django21
+
+    - python: 3.7
+      env: TOXENV=py37-django20
+
+    - python: 3.7
+      env: TOXENV=py37-django21
+
+before_install:
+  - if [ -z $DOCUSIGN_INTEGRATOR_KEY ]; then echo "Missing docusign integrator key"; exit 1; fi
+
 install:
   - make develop
 
 script:
   - make test
+

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -97,7 +97,7 @@ get the setup. Here is an example to run the tests:
 
 .. _`django-docusign bugtracker`: https://github.com/peopledoc/django-docusign/issues
 .. _`rebase`: http://git-scm.com/book/en/Git-Branching-Rebasing
-.. _`merge-based rebase`: http://tech.novapost.fr/psycho-rebasing-en.html
+.. _`merge-based rebase`: http://tech.novapost.fr/psycho-rebasing.html
 .. _`pip`: https://pypi.org/project/pip/
 .. _`tox`: https://pypi.org/project/tox/
 .. _`Sphinx`: https://pypi.org/project/Sphinx/

--- a/demo/django_docusign_demo/forms.py
+++ b/demo/django_docusign_demo/forms.py
@@ -5,7 +5,8 @@ from django import forms
 from django.forms.formsets import formset_factory
 from django.utils.translation import ugettext_lazy as _
 from django_docusign import api as django_docusign
-from formsetfield.fields import FormSetField
+
+from .formsetfield.fields import FormSetField
 
 
 class SettingsForm(forms.Form):

--- a/demo/django_docusign_demo/formsetfield/fields.py
+++ b/demo/django_docusign_demo/formsetfield/fields.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2012, Mike Yumatov <mike@yumatov.org>
+
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from django import forms
+from .widgets import FormSetWidget
+
+
+class FormSetField(forms.Field):
+
+    widget = FormSetWidget
+
+    def __init__(self, formset_class, template=None, *args, **kwargs):
+        self.formset_class = formset_class
+        self.template = template or 'formsetfield/formsetfield.html'
+        super(FormSetField, self).__init__(*args, **kwargs)
+
+    def validate(self, value):
+        if not value.is_valid():
+            raise forms.ValidationError(self.error_messages['invalid'])
+
+    def clean(self, value):
+        return super(FormSetField, self).clean(value).cleaned_data
+
+    def widget_attrs(self, widget):
+        return {'formset_class': self.formset_class, 'template': self.template}

--- a/demo/django_docusign_demo/formsetfield/widgets.py
+++ b/demo/django_docusign_demo/formsetfield/widgets.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2012, Mike Yumatov <mike@yumatov.org>
+
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from django import forms
+from django.template.loader import render_to_string
+
+
+class FormSetWidget(forms.Widget):
+
+    def render(self, name, value, attrs=None, renderer=None):
+        if value is None:
+            value = self.attrs['formset_class'](prefix=name)
+        return render_to_string(self.attrs['template'], {'formset': value})
+
+    def value_from_datadict(self, data, files, name):
+        return self.attrs['formset_class'](data, files, prefix=name)

--- a/demo/django_docusign_demo/settings.py
+++ b/demo/django_docusign_demo/settings.py
@@ -64,8 +64,6 @@ INSTALLED_APPS = (
     'django_docusign_demo',
     'django_docusign',
     'django_anysign',
-    # Third-parties.
-    'formsetfield',
     # Standard Django applications.
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/demo/django_docusign_demo/templates/formsetfield/formsetfield.html
+++ b/demo/django_docusign_demo/templates/formsetfield/formsetfield.html
@@ -1,0 +1,1 @@
+<table>{{ formset }}</table>

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -31,7 +31,6 @@ KEYWORDS = []
 PACKAGES = ['django_docusign_demo']
 REQUIREMENTS = [
     'django-docusign',
-    'django-formsetfield',
     'django-nose',
     'setuptools',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{27,34,35}-django{18,19,110}
     py{27,34,35,36}-django111
     py{34,35,36}-django20
+    py{35,36,37}-django21
     flake8
     sphinx
     readme
@@ -13,6 +14,7 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 deps =
     coverage
     django18: Django>=1.8,<1.9
@@ -20,6 +22,7 @@ deps =
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     py27: mock
     nose
     nose-exclude


### PR DESCRIPTION
This PR replaces the [PR #90](https://github.com/peopledoc/django-docusign/pull/90) with valid environment variables for docusign.